### PR TITLE
Fix plugins field type in FuseBoxOptions interface

### DIFF
--- a/src/core/FuseBox.ts
+++ b/src/core/FuseBox.ts
@@ -39,7 +39,7 @@ export interface FuseBoxOptions {
     target?: string,
     log?: boolean;
     globals?: { [packageName: string]: /** Variable name */ string };
-    plugins?: Plugin[] | [Plugin[]];
+    plugins?: Array<Plugin | Plugin[]>;
     autoImport?: any;
     natives?: any;
     warnings?: boolean,


### PR DESCRIPTION
The old type was `Plugin[] | [Plugin[]]` ((array of Plugin) **or** (array of array of Plugin)) while I suggest `Array<Plugin | Plugin[]>`  (array of (Plugin **or** array of Plugin)). Only the latest is compatible with `fuse-box-examples` which have, on many occasions, an array of CSS-related plugins mixed up with single plugins.